### PR TITLE
Extract sql operations into executors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.mdennis10</groupId>
     <artifactId>jdbc-helper</artifactId>
-    <version>2.1.4</version>
+    <version>2.1.5</version>
     <properties>
         <junit.jupiter.version>5.7.0</junit.jupiter.version>
         <junit.platform.version>1.7.0</junit.platform.version>

--- a/src/main/java/com/github/mdennis10/jdbc_helper/DatabaseHelper.java
+++ b/src/main/java/com/github/mdennis10/jdbc_helper/DatabaseHelper.java
@@ -7,12 +7,8 @@ import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 public final class DatabaseHelper {
@@ -143,25 +139,4 @@ public final class DatabaseHelper {
             return;
         connectionManager.close();
     }
-
-
-    private void resolveParameters(PreparedStatement preparedStatement, Object[] parameters) throws SQLException {
-        for (int x = 0; x < parameters.length; x++) {
-            preparedStatement.setObject(x + 1, parameters[x]);
-        }
-    }
-
-    private Map<String, Object> parseRow(ResultSet resultSet) throws SQLException {
-        Map<String, Object> columnMetaData = new HashMap<>();
-        int column = resultSet.getMetaData().getColumnCount();
-        for (int x = 1; x <= column;x++) {
-            String columnName = resultSet.getMetaData().getColumnName(x);
-            Object columnValue = resultSet.getObject(x);
-            if(columnName != null) {
-                columnMetaData.put(columnName.toUpperCase(), columnValue);
-            }
-        }
-        return columnMetaData;
-    }
-
 }

--- a/src/main/java/com/github/mdennis10/jdbc_helper/DatabaseHelper.java
+++ b/src/main/java/com/github/mdennis10/jdbc_helper/DatabaseHelper.java
@@ -2,8 +2,6 @@ package com.github.mdennis10.jdbc_helper;
 
 
 import com.github.mdennis10.jdbc_helper.exception.DatabaseHelperSQLException;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
@@ -12,7 +10,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public final class DatabaseHelper {
     private static ConnectionManager connectionManager;
@@ -55,22 +56,7 @@ public final class DatabaseHelper {
      * @return single row of result extracted from mapper
      */
     public <T> Optional<T> query(@NotNull String sql, @NotNull Object[] arguments, @NotNull ColumnMapper<T> mapper) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql),"Null or empty sql argument supplied");
-        Preconditions.checkNotNull(arguments, "Null SQL parameter arguments supplied");
-        Preconditions.checkNotNull(mapper, "Null mapper supplied");
-        try(Connection conn = getConnection(config);
-            PreparedStatement stmt = conn.prepareStatement(sql)) {
-            resolveParameters(stmt, arguments);
-            try (ResultSet resultSet = stmt.executeQuery()) {
-                while (resultSet.next()) {
-                    T result = mapper.map(parseRow(resultSet));
-                    return (result != null) ? Optional.of(result) : Optional.empty();
-                }
-                return Optional.empty();
-            }
-        } catch (SQLException e) {
-            throw new DatabaseHelperSQLException(e.getMessage());
-        }
+        return queryExecutor.query(true, getConnection(config), sql, arguments, mapper);
     }
 
     /**
@@ -83,23 +69,7 @@ public final class DatabaseHelper {
      * @return instance of entity class with result row mapped
      */
     public <T> Optional<T> query(@NotNull Class<T> clazz,@NotNull String sql, @NotNull Object[] arguments) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql), "Null or empty sql argument supplied");
-        Preconditions.checkNotNull(clazz, "Null clazz argument supplied");
-        Preconditions.checkNotNull(arguments,"Null SQL parameter arguments supplied" );
-        try(Connection conn = getConnection(config);
-            PreparedStatement stmt = conn.prepareStatement(sql)){
-            resolveParameters(stmt, arguments);
-            try(ResultSet resultSet = stmt.executeQuery()) {
-                while (resultSet.next()) {
-                    Map<String, Object> dataResult = parseRow(resultSet);
-                    T resolved = ReflectiveTypeResolver.resolve(clazz, dataResult);
-                    return (resolved != null) ? Optional.of(resolved) : Optional.empty();
-                }
-            }
-        } catch (SQLException e) {
-            throw new DatabaseHelperSQLException(e.getMessage());
-        }
-        return Optional.empty();
+        return queryExecutor.query(true, getConnection(config), clazz, sql, arguments);
     }
 
 
@@ -113,23 +83,7 @@ public final class DatabaseHelper {
      * @return rows of results extracted from mapper
      */
     public <T> List<T> queryForList(@NotNull String sql, @NotNull Object[] arguments, ColumnMapper<T> mapper){
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql),"Null or empty sql argument supplied");
-        Preconditions.checkNotNull(arguments, "Null SQL parameter arguments supplied");
-        Preconditions.checkNotNull(mapper, "Null mapper supplied");
-        try (Connection conn = getConnection(config);
-             PreparedStatement stmt = conn.prepareStatement(sql)) {
-            resolveParameters(stmt, arguments);
-            try (ResultSet resultSet = stmt.executeQuery())  {
-                List<T> result = new ArrayList<>();
-                while (resultSet.next()) {
-                    T row = mapper.map(parseRow(resultSet));
-                    result.add(row);
-                }
-                return result;
-            }
-        } catch (SQLException e) {
-            throw new DatabaseHelperSQLException(e.getMessage());
-        }
+        return queryExecutor.queryForList(true, getConnection(config), sql, arguments, mapper);
     }
 
     /**
@@ -142,23 +96,7 @@ public final class DatabaseHelper {
      * @return rows of results extracted from mapper
      */
     public <T> List<T> queryForList(@NotNull Class<T> clazz, @NotNull String sql, @NotNull Object[] arguments) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql),"Null or empty sql argument supplied");
-        Preconditions.checkNotNull(arguments, "Null SQL parameter arguments supplied");
-        Preconditions.checkNotNull(clazz, "Null clazz argument supplied");
-        try(Connection conn = getConnection(config);
-            PreparedStatement stmt = conn.prepareStatement(sql)) {
-            resolveParameters(stmt, arguments);
-            try(ResultSet resultSet = stmt.executeQuery()) {
-                List<T> result = new ArrayList<>();
-                while(resultSet.next()) {
-                    Map<String, Object> dataResult = parseRow(resultSet);
-                    result.add(ReflectiveTypeResolver.resolve(clazz, dataResult));
-                }
-                return result;
-            }
-        } catch (SQLException e) {
-            throw new DatabaseHelperSQLException(e.getMessage());
-        }
+        return queryExecutor.queryForList(true, getConnection(config), clazz, sql, arguments);
     }
 
     /**
@@ -170,16 +108,7 @@ public final class DatabaseHelper {
      * @return number of rows affected
      */
     public int executeUpdate(@NotNull String sql, @Nullable Object[] arguments) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql), "Null or empty sql argument supplied");
-        try (Connection conn = getConnection(config);
-             PreparedStatement stmt = conn.prepareStatement(sql)) {
-            if(arguments != null) {
-                resolveParameters(stmt, arguments);
-            }
-            return stmt.executeUpdate();
-        } catch (SQLException e) {
-            throw new DatabaseHelperSQLException(e.getMessage());
-        }
+        return updateExecutor.executeUpdate(true, getConnection(config), sql, arguments);
     }
 
     /**
@@ -191,22 +120,7 @@ public final class DatabaseHelper {
      * @return number of rows affected
      */
     public int[] executeBatchUpdate(@NotNull String sql, @NotNull List<Object[]> arguments) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql), "Null or empty sql argument supplied");
-        Preconditions.checkNotNull(arguments, "Null arguments argument supplied");
-        try(Connection conn = getConnection(config);
-            PreparedStatement stmt = conn.prepareStatement(sql)) {
-            if(arguments.size() == 0) {
-                stmt.addBatch();
-                return stmt.executeBatch();
-            }
-            for(Object[] param : arguments) {
-                resolveParameters(stmt, param);
-                stmt.addBatch();
-            }
-            return stmt.executeBatch();
-        } catch (SQLException e) {
-            throw new DatabaseHelperSQLException(e.getMessage());
-        }
+        return updateExecutor.executeBatchUpdate(true, getConnection(config), sql, arguments);
     }
 
     /**

--- a/src/main/java/com/github/mdennis10/jdbc_helper/QueryExecutor.java
+++ b/src/main/java/com/github/mdennis10/jdbc_helper/QueryExecutor.java
@@ -24,7 +24,7 @@ public class QueryExecutor {
         Preconditions.checkNotNull(connection, "Null connection provided");
         Preconditions.checkArgument(!Strings.isNullOrEmpty(sql), "Null or empty sql argument supplied");
         Preconditions.checkNotNull(arguments,"Null SQL parameter arguments supplied" );
-        Preconditions.checkNotNull(mapper, "Null mapper argument supplied");
+        Preconditions.checkNotNull(mapper, "Null mapper supplied");
         try {
             if(isAutoClose) {
                 try(Connection conn = connection;
@@ -99,7 +99,7 @@ public class QueryExecutor {
         Preconditions.checkNotNull(connection, "Null connection provided");
         Preconditions.checkArgument(!Strings.isNullOrEmpty(sql),"Null or empty sql argument supplied");
         Preconditions.checkNotNull(arguments, "Null SQL parameter arguments supplied");
-        Preconditions.checkNotNull(mapper, "Null mapper argument supplied");
+        Preconditions.checkNotNull(mapper, "Null mapper supplied");
         try {
             if(isAutoClose) {
                 try (Connection conn = connection;

--- a/src/main/java/com/github/mdennis10/jdbc_helper/QueryExecutor.java
+++ b/src/main/java/com/github/mdennis10/jdbc_helper/QueryExecutor.java
@@ -15,7 +15,38 @@ import java.util.Map;
 import java.util.Optional;
 
 public class QueryExecutor {
-    protected <T> Optional<T> query(boolean isAutoClose, @NotNull Connection connection, @NotNull Class<T> clazz, @NotNull String sql, @NotNull Object[] arguments) {
+    protected <T> Optional<T> query(
+            boolean isAutoClose,
+            @NotNull Connection connection,
+            @NotNull String sql,
+            @NotNull Object[] arguments,
+            @NotNull ColumnMapper<T> mapper) {
+        Preconditions.checkNotNull(connection, "Null connection provided");
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql), "Null or empty sql argument supplied");
+        Preconditions.checkNotNull(arguments,"Null SQL parameter arguments supplied" );
+        Preconditions.checkNotNull(mapper, "Null mapper argument supplied");
+        try {
+            if(isAutoClose) {
+                try(Connection conn = connection;
+                    PreparedStatement stmt = conn.prepareStatement(sql)){
+                    return executeQueryWithMapper(stmt, arguments, mapper);
+                }
+            } else {
+                PreparedStatement stmt = connection.prepareStatement(sql);
+                return executeQueryWithMapper(stmt, arguments, mapper);
+            }
+        } catch (SQLException e) {
+            throw new DatabaseHelperSQLException(e);
+        }
+    }
+
+    protected <T> Optional<T> query(
+            boolean isAutoClose,
+            @NotNull Connection connection,
+            @NotNull Class<T> clazz,
+            @NotNull String sql,
+            @NotNull Object[] arguments) {
+        Preconditions.checkNotNull(connection, "Null connection provided");
         Preconditions.checkArgument(!Strings.isNullOrEmpty(sql), "Null or empty sql argument supplied");
         Preconditions.checkNotNull(clazz, "Null clazz argument supplied");
         Preconditions.checkNotNull(arguments,"Null SQL parameter arguments supplied" );
@@ -34,19 +65,13 @@ public class QueryExecutor {
         }
     }
 
-    private <T> Optional<T> executeQuery(Class<T> clazz, PreparedStatement stmt, Object[] arguments) throws SQLException {
-        ExecutorHelperUtil.resolveParameters(stmt, arguments);
-        try(ResultSet resultSet = stmt.executeQuery()) {
-            while (resultSet.next()) {
-                Map<String, Object> dataResult = ExecutorHelperUtil.parseRow(resultSet);
-                T resolved = ReflectiveTypeResolver.resolve(clazz, dataResult);
-                return (resolved != null) ? Optional.of(resolved) : Optional.empty();
-            }
-        }
-        return Optional.empty();
-    }
-
-    protected <T> List<T> queryForList(boolean isAutoClose,@NotNull Connection connection, @NotNull Class<T> clazz, @NotNull String sql, @NotNull Object[] arguments) {
+    protected <T> List<T> queryForList(
+            boolean isAutoClose,
+            @NotNull Connection connection,
+            @NotNull Class<T> clazz,
+            @NotNull String sql,
+            @NotNull Object[] arguments) {
+        Preconditions.checkNotNull(connection, "Null connection provided");
         Preconditions.checkArgument(!Strings.isNullOrEmpty(sql),"Null or empty sql argument supplied");
         Preconditions.checkNotNull(arguments, "Null SQL parameter arguments supplied");
         Preconditions.checkNotNull(clazz, "Null clazz argument supplied");
@@ -65,6 +90,54 @@ public class QueryExecutor {
         }
     }
 
+    protected <T> List<T> queryForList(
+            boolean isAutoClose,
+            @NotNull Connection connection,
+            @NotNull String sql,
+            @NotNull Object[] arguments,
+            @NotNull ColumnMapper<T> mapper) {
+        Preconditions.checkNotNull(connection, "Null connection provided");
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql),"Null or empty sql argument supplied");
+        Preconditions.checkNotNull(arguments, "Null SQL parameter arguments supplied");
+        Preconditions.checkNotNull(mapper, "Null mapper argument supplied");
+        try {
+            if(isAutoClose) {
+                try (Connection conn = connection;
+                     PreparedStatement stmt = conn.prepareStatement(sql)) {
+                    return executeQueryForListWithMapper(stmt, arguments, mapper);
+                }
+            } else {
+                PreparedStatement stmt = connection.prepareStatement(sql);
+                return executeQueryForListWithMapper(stmt, arguments, mapper);
+            }
+        } catch (SQLException e) {
+            throw new DatabaseHelperSQLException(e);
+        }
+    }
+
+    private <T> Optional<T> executeQueryWithMapper(PreparedStatement stmt, Object[] arguments, ColumnMapper<T> mapper) throws SQLException {
+        ExecutorHelperUtil.resolveParameters(stmt, arguments);
+        try(ResultSet resultSet = stmt.executeQuery()) {
+            while (resultSet.next()) {
+                T result = mapper.map(ExecutorHelperUtil.parseRow(resultSet));
+                return (result != null) ? Optional.of(result) : Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
+    private <T> Optional<T> executeQuery(Class<T> clazz, PreparedStatement stmt, Object[] arguments) throws SQLException {
+        ExecutorHelperUtil.resolveParameters(stmt, arguments);
+        try(ResultSet resultSet = stmt.executeQuery()) {
+            while (resultSet.next()) {
+                Map<String, Object> dataResult = ExecutorHelperUtil.parseRow(resultSet);
+                T resolved = ReflectiveTypeResolver.resolve(clazz, dataResult);
+                return (resolved != null) ? Optional.of(resolved) : Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
     private <T> List<T> executeQueryForList(Class<T> clazz, PreparedStatement stmt, Object[] arguments) throws SQLException {
         ExecutorHelperUtil.resolveParameters(stmt, arguments);
         try(ResultSet resultSet = stmt.executeQuery()) {
@@ -72,6 +145,21 @@ public class QueryExecutor {
             while(resultSet.next()) {
                 Map<String, Object> dataResult = ExecutorHelperUtil.parseRow(resultSet);
                 result.add(ReflectiveTypeResolver.resolve(clazz, dataResult));
+            }
+            return result;
+        }
+    }
+
+    private <T> List<T> executeQueryForListWithMapper(
+            PreparedStatement stmt,
+            Object[] arguments,
+            ColumnMapper<T> mapper) throws SQLException {
+        ExecutorHelperUtil.resolveParameters(stmt, arguments);
+        try(ResultSet resultSet = stmt.executeQuery()) {
+            List<T> result = new ArrayList<>();
+            while(resultSet.next()) {
+                T row = mapper.map(ExecutorHelperUtil.parseRow(resultSet));
+                result.add(row);
             }
             return result;
         }

--- a/src/main/java/com/github/mdennis10/jdbc_helper/UpdateExecutor.java
+++ b/src/main/java/com/github/mdennis10/jdbc_helper/UpdateExecutor.java
@@ -29,13 +29,6 @@ public class UpdateExecutor {
         }
     }
 
-    private int executeUpdate(PreparedStatement stmt, Object[] arguments) throws SQLException {
-        if(arguments != null) {
-            ExecutorHelperUtil.resolveParameters(stmt, arguments);
-        }
-        return stmt.executeUpdate();
-    }
-
     protected int[] executeBatchUpdate(boolean isAutoClose, @NotNull Connection connection, @NotNull String sql, @NotNull List<Object[]> arguments) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(sql), "Null or empty sql argument supplied");
         Preconditions.checkNotNull(arguments, "Null arguments argument supplied");
@@ -53,6 +46,14 @@ public class UpdateExecutor {
             throw new DatabaseHelperSQLException(e);
         }
     }
+
+    private int executeUpdate(PreparedStatement stmt, Object[] arguments) throws SQLException {
+        if(arguments != null) {
+            ExecutorHelperUtil.resolveParameters(stmt, arguments);
+        }
+        return stmt.executeUpdate();
+    }
+
 
     private int[] executeBatchUpdate(PreparedStatement stmt, List<Object[]> arguments) throws SQLException  {
         if(arguments.size() == 0) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Create two main executors one to execute update operations  and one for query operations.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Extract sql operations into executors](https://github.com/mdennis10/jdbc-helper/issues/11)

## How Has This Been Tested?
<!--- How was this tested? Put an `x` in all the boxes that apply: -->
- [x] Unit Test
- [ ] Manually Test.

## Additional Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Mockito
- JUnit 5
- h2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
